### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -23,7 +23,7 @@ PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Compo
 
 PIPSWITCH_SCHEMA = switch.switch_schema(
     PowermustSwitch, icon=ICON_POWER, block_inverted=True
-).extend(cv.COMPONENT_SCHEMA)
+)
 
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {cv.Optional(type): PIPSWITCH_SCHEMA for type in TYPES}


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from `switch.switch_schema()` calls
- `switch_schema()` includes the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant