### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -34,9 +34,9 @@ PIPSWITCH_CONFIG_SCHEMA = switch.switch_schema(
 
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(type): PIPSWITCH_CONFIG_SCHEMA
-        if type == CONF_BEEPER
-        else PIPSWITCH_SCHEMA
+        cv.Optional(type): (
+            PIPSWITCH_CONFIG_SCHEMA if type == CONF_BEEPER else PIPSWITCH_SCHEMA
+        )
         for type in TYPES
     }
 )

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -13,31 +13,32 @@ CONF_DEEP_TEST = "deep_test"
 CONF_TEN_MINUTES_TEST = "ten_minutes_test"
 
 TYPES = {
-    CONF_BEEPER: ("Q", "Q", ENTITY_CATEGORY_CONFIG),
-    CONF_QUICK_TEST: ("T", "CT", None),
-    CONF_DEEP_TEST: ("TL", "CT", None),
-    CONF_TEN_MINUTES_TEST: ("T10", "CT", None),
+    CONF_BEEPER: ("Q", "Q"),
+    CONF_QUICK_TEST: ("T", "CT"),
+    CONF_DEEP_TEST: ("TL", "CT"),
+    CONF_TEN_MINUTES_TEST: ("T10", "CT"),
 }
 
 PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Component)
 
+SWITCH_SCHEMAS = {
+    CONF_BEEPER: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
+    CONF_QUICK_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_DEEP_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_TEN_MINUTES_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+}
+
+assert set(TYPES) == set(SWITCH_SCHEMAS), "TYPES and SWITCH_SCHEMAS are out of sync"
+
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(type): switch.switch_schema(
-            PowermustSwitch,
-            icon=ICON_POWER,
-            block_inverted=True,
-            **({} if cat is None else {"entity_category": cat}),
-        ).extend(cv.COMPONENT_SCHEMA)
-        for type, (_, _, cat) in TYPES.items()
-    }
+    {cv.Optional(type): SWITCH_SCHEMAS[type] for type in TYPES}
 )
 
 
 async def to_code(config):
     paren = await cg.get_variable(config[CONF_POWERMUST_ID])
 
-    for type, (on, off, _) in TYPES.items():
+    for type, (on, off) in TYPES.items():
         if type in config:
             conf = config[type]
             var = await switch.new_switch(conf)

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -23,10 +23,21 @@ PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Compo
 
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG),
-        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_BEEPER): switch.switch_schema(
+            PowermustSwitch,
+            icon=ICON_POWER,
+            block_inverted=True,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(
+            PowermustSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(
+            PowermustSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(
+            PowermustSwitch, icon=ICON_POWER, block_inverted=True
+        ),
     }
 )
 

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -13,31 +13,23 @@ CONF_DEEP_TEST = "deep_test"
 CONF_TEN_MINUTES_TEST = "ten_minutes_test"
 
 TYPES = {
-    CONF_BEEPER: ("Q", "Q"),
-    CONF_QUICK_TEST: ("T", "CT"),
-    CONF_DEEP_TEST: ("TL", "CT"),
-    CONF_TEN_MINUTES_TEST: ("T10", "CT"),
+    CONF_BEEPER: ("Q", "Q", ENTITY_CATEGORY_CONFIG),
+    CONF_QUICK_TEST: ("T", "CT", None),
+    CONF_DEEP_TEST: ("TL", "CT", None),
+    CONF_TEN_MINUTES_TEST: ("T10", "CT", None),
 }
 
 PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Component)
 
-PIPSWITCH_SCHEMA = switch.switch_schema(
-    PowermustSwitch, icon=ICON_POWER, block_inverted=True
-).extend(cv.COMPONENT_SCHEMA)
-
-PIPSWITCH_CONFIG_SCHEMA = switch.switch_schema(
-    PowermustSwitch,
-    icon=ICON_POWER,
-    block_inverted=True,
-    entity_category=ENTITY_CATEGORY_CONFIG,
-).extend(cv.COMPONENT_SCHEMA)
-
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(type): (
-            PIPSWITCH_CONFIG_SCHEMA if type == CONF_BEEPER else PIPSWITCH_SCHEMA
-        )
-        for type in TYPES
+        cv.Optional(type): switch.switch_schema(
+            PowermustSwitch,
+            icon=ICON_POWER,
+            block_inverted=True,
+            **({} if cat is None else {"entity_category": cat}),
+        ).extend(cv.COMPONENT_SCHEMA)
+        for type, (_, _, cat) in TYPES.items()
     }
 )
 
@@ -45,7 +37,7 @@ CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
 async def to_code(config):
     paren = await cg.get_variable(config[CONF_POWERMUST_ID])
 
-    for type, (on, off) in TYPES.items():
+    for type, (on, off, _) in TYPES.items():
         if type in config:
             conf = config[type]
             var = await switch.new_switch(conf)

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -23,10 +23,10 @@ PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Compo
 
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_BEEPER): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True),
     }
 )
 

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -21,17 +21,13 @@ TYPES = {
 
 PowermustSwitch = powermust_ns.class_("PowermustSwitch", switch.Switch, cg.Component)
 
-SWITCH_SCHEMAS = {
-    CONF_BEEPER: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
-    CONF_QUICK_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_DEEP_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_TEN_MINUTES_TEST: switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-}
-
-assert set(TYPES) == set(SWITCH_SCHEMAS), "TYPES and SWITCH_SCHEMAS are out of sync"
-
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
-    {cv.Optional(type): SWITCH_SCHEMAS[type] for type in TYPES}
+    {
+        cv.Optional(CONF_BEEPER): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(PowermustSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    }
 )
 
 

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_BEEPER, ICON_POWER
+from esphome.const import CONF_BEEPER, ENTITY_CATEGORY_CONFIG, ICON_POWER
 
 from .. import CONF_POWERMUST_ID, POWERMUST_COMPONENT_SCHEMA, powermust_ns
 
@@ -25,8 +25,20 @@ PIPSWITCH_SCHEMA = switch.switch_schema(
     PowermustSwitch, icon=ICON_POWER, block_inverted=True
 ).extend(cv.COMPONENT_SCHEMA)
 
+PIPSWITCH_CONFIG_SCHEMA = switch.switch_schema(
+    PowermustSwitch,
+    icon=ICON_POWER,
+    block_inverted=True,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+).extend(cv.COMPONENT_SCHEMA)
+
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
-    {cv.Optional(type): PIPSWITCH_SCHEMA for type in TYPES}
+    {
+        cv.Optional(CONF_BEEPER): PIPSWITCH_CONFIG_SCHEMA,
+        cv.Optional(CONF_QUICK_TEST): PIPSWITCH_SCHEMA,
+        cv.Optional(CONF_DEEP_TEST): PIPSWITCH_SCHEMA,
+        cv.Optional(CONF_TEN_MINUTES_TEST): PIPSWITCH_SCHEMA,
+    }
 )
 
 

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -34,10 +34,10 @@ PIPSWITCH_CONFIG_SCHEMA = switch.switch_schema(
 
 CONFIG_SCHEMA = POWERMUST_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): PIPSWITCH_CONFIG_SCHEMA,
-        cv.Optional(CONF_QUICK_TEST): PIPSWITCH_SCHEMA,
-        cv.Optional(CONF_DEEP_TEST): PIPSWITCH_SCHEMA,
-        cv.Optional(CONF_TEN_MINUTES_TEST): PIPSWITCH_SCHEMA,
+        cv.Optional(type): PIPSWITCH_CONFIG_SCHEMA
+        if type == CONF_BEEPER
+        else PIPSWITCH_SCHEMA
+        for type in TYPES
     }
 )
 


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.