### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/powermust/binary_sensor/__init__.py
+++ b/components/powermust/binary_sensor/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from .. import CONF_POWERMUST_ID, POWERMUST_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 CONF_FAULTS_PRESENT = "faults_present"
 

--- a/components/powermust/sensor/__init__.py
+++ b/components/powermust/sensor/__init__.py
@@ -18,6 +18,7 @@ from esphome.const import (
 from .. import CONF_POWERMUST_ID, POWERMUST_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 # Q1 sensors
 CONF_GRID_VOLTAGE = "grid_voltage"

--- a/components/powermust/switch/__init__.py
+++ b/components/powermust/switch/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_BEEPER, ENTITY_CATEGORY_CONFIG, ICON_POWER
 from .. import CONF_POWERMUST_ID, POWERMUST_COMPONENT_SCHEMA, powermust_ns
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 # CONF_BEEPER = "beeper"
 CONF_QUICK_TEST = "quick_test"

--- a/components/powermust/text_sensor/__init__.py
+++ b/components/powermust/text_sensor/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from .. import CONF_POWERMUST_ID, POWERMUST_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 CONF_LAST_Q1 = "last_q1"
 CONF_LAST_F = "last_f"


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `sensor/__init__.py`, `binary_sensor/__init__.py`, `text_sensor/__init__.py`, and `switch/__init__.py` for consistency with other ESPHome components.