### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/powermust/powermust.cpp
+++ b/components/powermust/powermust.cpp
@@ -1,8 +1,7 @@
 #include "powermust.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace powermust {
+namespace esphome::powermust {
 
 static const char *const TAG = "powermust";
 
@@ -360,5 +359,4 @@ void Powermust::add_polling_command_(const char *command, ENUMPollingCommand pol
   }
 }
 
-}  // namespace powermust
-}  // namespace esphome
+}  // namespace esphome::powermust

--- a/components/powermust/powermust.h
+++ b/components/powermust/powermust.h
@@ -8,8 +8,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace powermust {
+namespace esphome::powermust {
 
 enum ENUMPollingCommand {
   POLLING_Q1 = 0,
@@ -116,5 +115,4 @@ class Powermust : public uart::UARTDevice, public PollingComponent {
   PollingCommand used_polling_commands_[15];
 };
 
-}  // namespace powermust
-}  // namespace esphome
+}  // namespace esphome::powermust

--- a/components/powermust/switch/powermust_switch.cpp
+++ b/components/powermust/switch/powermust_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace powermust {
+namespace esphome::powermust {
 
 static const char *const TAG = "powermust.switch";
 
@@ -20,5 +19,4 @@ void PowermustSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace powermust
-}  // namespace esphome
+}  // namespace esphome::powermust

--- a/components/powermust/switch/powermust_switch.h
+++ b/components/powermust/switch/powermust_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace powermust {
+namespace esphome::powermust {
 class Powermust;
 class PowermustSwitch : public switch_::Switch, public Component {
  public:
@@ -21,5 +20,4 @@ class PowermustSwitch : public switch_::Switch, public Component {
   Powermust *parent_;
 };
 
-}  // namespace powermust
-}  // namespace esphome
+}  // namespace esphome::powermust


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.