### PR TITLE
Replace sscanf float parsing with strtof/strtol

### DIFF
--- a/components/powermust/powermust.cpp
+++ b/components/powermust/powermust.cpp
@@ -135,22 +135,25 @@ void Powermust::loop() {
         // (232.9 232.9 232.9 003 49.9 13.4 25.0 00001000\r
         // (005.2 232.4 226.8 002 50.1 12.9 25.0 10001000\r
         //                                 1  2  3  4  5  6  7  8
-        sscanf(tmp, "(%f %f %f %d %f %f %f %1d%1d%1d%1d%1d%1d%1d%1d",  // NOLINT
-               &value_grid_voltage_,                                   // NOLINT
-               &value_grid_fault_voltage_,                             // NOLINT
-               &value_ac_output_voltage_,                              // NOLINT
-               &value_ac_output_load_percent_,                         // NOLINT
-               &value_grid_frequency_,                                 // NOLINT
-               &value_battery_voltage_,                                // NOLINT
-               &value_temperature_,                                    // NOLINT
-               &value_utility_fail_,                                   // NOLINT
-               &value_battery_low_,                                    // NOLINT
-               &value_bypass_active_,                                  // NOLINT
-               &value_ups_failed_,                                     // NOLINT
-               &value_ups_type_standby_,                               // NOLINT
-               &value_test_in_progress_,                               // NOLINT
-               &value_shutdown_active_,                                // NOLINT
-               &value_beeper_on_);                                     // NOLINT
+        {
+          char *p = const_cast<char *>(tmp) + 1;  // skip '('
+          value_grid_voltage_ = strtof(p, &p);
+          value_grid_fault_voltage_ = strtof(p, &p);
+          value_ac_output_voltage_ = strtof(p, &p);
+          value_ac_output_load_percent_ = strtol(p, &p, 10);
+          value_grid_frequency_ = strtof(p, &p);
+          value_battery_voltage_ = strtof(p, &p);
+          value_temperature_ = strtof(p, &p);
+          while (*p == ' ') p++;
+          value_utility_fail_ = *p++ - '0';
+          value_battery_low_ = *p++ - '0';
+          value_bypass_active_ = *p++ - '0';
+          value_ups_failed_ = *p++ - '0';
+          value_ups_type_standby_ = *p++ - '0';
+          value_test_in_progress_ = *p++ - '0';
+          value_shutdown_active_ = *p++ - '0';
+          value_beeper_on_ = *p - '0';
+        }
         if (this->last_q1_) {
           this->last_q1_->publish_state(tmp);
         }
@@ -159,13 +162,13 @@ void Powermust::loop() {
       case POLLING_F:
         ESP_LOGD(TAG, "Decode F");
         // "#220.0 003 12.00 50.0\r"
-        sscanf(                                   // NOLINT
-            tmp,                                  // NOLINT
-            "#%f %d %f %f",                       // NOLINT
-            &value_ac_output_rating_voltage_,     // NOLINT
-            &value_ac_output_rating_current_,     // NOLINT
-            &value_battery_rating_voltage_,       // NOLINT
-            &value_ac_output_rating_frequency_);  // NOLINT
+        {
+          char *p = const_cast<char *>(tmp) + 1;  // skip '#'
+          value_ac_output_rating_voltage_ = strtof(p, &p);
+          value_ac_output_rating_current_ = strtol(p, &p, 10);
+          value_battery_rating_voltage_ = strtof(p, &p);
+          value_ac_output_rating_frequency_ = strtof(p, &p);
+        }
         if (this->last_f_) {
           this->last_f_->publish_state(tmp);
         }

--- a/components/powermust/powermust.cpp
+++ b/components/powermust/powermust.cpp
@@ -144,7 +144,8 @@ void Powermust::loop() {
           value_grid_frequency_ = strtof(p, &p);
           value_battery_voltage_ = strtof(p, &p);
           value_temperature_ = strtof(p, &p);
-          while (*p == ' ') p++;
+          while (*p == ' ')
+            p++;
           value_utility_fail_ = *p++ - '0';
           value_battery_low_ = *p++ - '0';
           value_bypass_active_ = *p++ - '0';

--- a/tests/components/powermust/powermust_test.cpp
+++ b/tests/components/powermust/powermust_test.cpp
@@ -110,6 +110,18 @@ TEST_F(PowermustQ1DecodeTest, UtilityFailTrue) {
   EXPECT_TRUE(utility_fail_.state);
 }
 
+TEST_F(PowermustQ1DecodeTest, AllFlagsTrue) {
+  ups_.decode_and_publish(POLLING_Q1, "(005.2 232.4 226.8 002 50.1 12.9 25.0 11111111\r");
+  EXPECT_TRUE(utility_fail_.state);
+  EXPECT_TRUE(battery_low_.state);
+  EXPECT_TRUE(bypass_active_.state);
+  EXPECT_TRUE(ups_failed_.state);
+  EXPECT_TRUE(ups_type_standby_.state);
+  EXPECT_TRUE(test_in_progress_.state);
+  EXPECT_TRUE(shutdown_active_.state);
+  EXPECT_TRUE(beeper_on_.state);
+}
+
 TEST_F(PowermustQ1DecodeTest, LastQ1Raw) {
   ups_.decode_and_publish(POLLING_Q1, "(232.9 232.9 232.9 003 49.9 13.4 25.0 00001000\r");
   EXPECT_EQ(last_q1_.state.substr(0, 10), "(232.9 232");


### PR DESCRIPTION
## Problem

On ESP8266, `sscanf` with `%f` format specifiers requires the `_scanf_float` linker symbol. ESPHome strips this symbol by default to save ~8KB flash, which silently breaks float parsing unless the user manually adds `enable_scanf_float: true` to their YAML config.

## Solution

Replace the two multi-field `sscanf` calls with explicit `strtof`/`strtol` pointer advancement. Both functions skip leading whitespace and advance the pointer on each call, making them a clean drop-in replacement for sscanf field-by-field parsing. No scanf machinery required, no YAML workaround needed.

The concatenated 8-bit status field in Q1 (`00001000`) is read directly as individual characters rather than via `%1d` repeated sscanf.

## Changes

- `POLLING_Q1`: replaces `sscanf("(%f %f %f %d %f %f %f %1d%1d%1d%1d%1d%1d%1d%1d", ...)` with sequential `strtof`/`strtol` + direct char reads for status bits
- `POLLING_F`: replaces `sscanf("#%f %d %f %f", ...)` with sequential `strtof`/`strtol`